### PR TITLE
updated thrift spec to support exec_single_batch_param

### DIFF
--- a/include/adbt_types.hrl
+++ b/include/adbt_types.hrl
@@ -51,10 +51,17 @@
                         'writeaccess' :: list()}).
 -type 'LoginResult'() :: #'LoginResult'{}.
 
+%% struct 'QueryResult'
+
+-record('QueryResult', {'rdRes' :: 'ReadResult'(),
+                        'wrRes' :: 'WriteResult'()}).
+-type 'QueryResult'() :: #'QueryResult'{}.
+
 %% struct 'Result'
 
 -record('Result', {'rdRes' :: 'ReadResult'(),
-                   'wrRes' :: 'WriteResult'()}).
+                   'wrRes' :: 'WriteResult'(),
+                   'batchRes' :: list()}).
 -type 'Result'() :: #'Result'{}.
 
 %% struct 'InvalidRequestException'

--- a/src/actordb_thrift.erl
+++ b/src/actordb_thrift.erl
@@ -78,11 +78,24 @@ function_info('exec_single_param', params_type) ->
           {2, string},
           {3, string},
           {4, {list, string}},
-          {5, {list, {list, {struct, {'adbt_types', 'Val'}}}}}]}
+          {5, {list, {list, {list, {struct, {'adbt_types', 'Val'}}}}}}]}
 ;
 function_info('exec_single_param', reply_type) ->
   {struct, {'adbt_types', 'Result'}};
 function_info('exec_single_param', exceptions) ->
+  {struct, [{1, {struct, {'adbt_types', 'InvalidRequestException'}}}]}
+;
+% exec_single_batch_param(This, Actorname, Actortype, Sql, Flags, Bindingvals)
+function_info('exec_single_batch_param', params_type) ->
+  {struct, [{1, string},
+          {2, string},
+          {3, string},
+          {4, {list, string}},
+          {5, {list, {list, {list, {struct, {'adbt_types', 'Val'}}}}}}]}
+;
+function_info('exec_single_batch_param', reply_type) ->
+  {struct, {'adbt_types', 'Result'}};
+function_info('exec_single_batch_param', exceptions) ->
   {struct, [{1, {struct, {'adbt_types', 'InvalidRequestException'}}}]}
 ;
 % exec_multi(This, Actors, Actortype, Sql, Flags)

--- a/src/adbt_types.erl
+++ b/src/adbt_types.erl
@@ -39,9 +39,15 @@ struct_info('LoginResult') ->
           {4, {list, string}}]}
 ;
 
-struct_info('Result') ->
+struct_info('QueryResult') ->
   {struct, [{1, {struct, {'adbt_types', 'ReadResult'}}},
           {2, {struct, {'adbt_types', 'WriteResult'}}}]}
+;
+
+struct_info('Result') ->
+  {struct, [{1, {struct, {'adbt_types', 'ReadResult'}}},
+          {2, {struct, {'adbt_types', 'WriteResult'}}},
+          {3, {list, {struct, {'adbt_types', 'QueryResult'}}}}]}
 ;
 
 struct_info('InvalidRequestException') ->
@@ -80,9 +86,15 @@ struct_info_ext('LoginResult') ->
           {4, optional, {list, string}, 'writeaccess', []}]}
 ;
 
-struct_info_ext('Result') ->
+struct_info_ext('QueryResult') ->
   {struct, [{1, undefined, {struct, {'adbt_types', 'ReadResult'}}, 'rdRes', #'ReadResult'{}},
           {2, undefined, {struct, {'adbt_types', 'WriteResult'}}, 'wrRes', #'WriteResult'{}}]}
+;
+
+struct_info_ext('Result') ->
+  {struct, [{1, undefined, {struct, {'adbt_types', 'ReadResult'}}, 'rdRes', #'ReadResult'{}},
+          {2, undefined, {struct, {'adbt_types', 'WriteResult'}}, 'wrRes', #'WriteResult'{}},
+          {3, undefined, {list, {struct, {'adbt_types', 'QueryResult'}}}, 'batchRes', []}]}
 ;
 
 struct_info_ext('InvalidRequestException') ->


### PR DESCRIPTION
Autogenerated code is updated as per the latest adbt thrift spec supporting `exec_single_batch_param` 

Signed-off-by: Ashwin S <ashwinsadeep@gmail.com>